### PR TITLE
refactor(warehouse): unify warehouse and store codes

### DIFF
--- a/src/pages/Dashboards/Product/components/CreateProductModal.tsx
+++ b/src/pages/Dashboards/Product/components/CreateProductModal.tsx
@@ -689,9 +689,8 @@ const CreateProductModal: FC<props> = memo(
                             onChange={validation.handleChange}
                             value={validation.values.warehouse || "Chọn"}
                           >
-                            <option value="Kho KS1">Kho KS1</option>
-                            <option value="Kho KS2">Kho KS2</option>
-                            <option value="Kho KH">Kho KH</option>
+                            <option value="KS">Kho KS</option>
+                            <option value="KH">Kho KH</option>
                           </select>
                           {validation.touched.warehouse &&
                           validation.errors.warehouse ? (

--- a/src/pages/Dashboards/Receipt/ReceiptCheck/ReceiptCheckUpdate.tsx
+++ b/src/pages/Dashboards/Receipt/ReceiptCheck/ReceiptCheckUpdate.tsx
@@ -436,9 +436,8 @@ const UpdateReceiptCheck = (props: any) => {
                       value={validation.values.warehouse || ""}
                     >
                       <option value="">Chọn kho</option>
-                      <option value="Kho KS1">Kho KS1</option>
-                      <option value="Kho KS2">Kho KS2</option>
-                      <option value="Kho KH">Kho KH</option>
+                      <option value="KS">Kho KS</option>
+                      <option value="KH">Kho KH</option>
                     </select>
                     {validation.touched.warehouse &&
                     validation.errors.warehouse ? (

--- a/src/pages/Dashboards/Receipt/ReceiptImport/ReceiptImportCreate.tsx
+++ b/src/pages/Dashboards/Receipt/ReceiptImport/ReceiptImportCreate.tsx
@@ -250,9 +250,8 @@ const CreateReceiptImport = (props: any) => {
                       value={validation.values.warehouse || ""}
                     >
                       <option value="">Chọn kho</option>
-                      <option value="Kho KS1">Kho KS1</option>
-                      <option value="Kho KS2">Kho KS2</option>
-                      <option value="Kho KH">Kho KH</option>
+                      <option value="KS">Kho KS</option>
+                      <option value="KH">Kho KH</option>
                     </select>
                     {validation.touched.warehouse &&
                     validation.errors.warehouse ? (

--- a/src/pages/Dashboards/Receipt/ReceiptImport/ReceiptImportUpdate.tsx
+++ b/src/pages/Dashboards/Receipt/ReceiptImport/ReceiptImportUpdate.tsx
@@ -481,9 +481,8 @@ const UpdateReceiptImport = (props: any) => {
                             value={validation.values.warehouse || ""}
                           >
                             <option value="">Chọn kho</option>
-                            <option value="Kho KS1">Kho KS1</option>
-                            <option value="Kho KS2">Kho KS2</option>
-                            <option value="Kho KH">Kho KH</option>
+                            <option value="KS">Kho KS</option>
+                            <option value="KH">Kho KH</option>
                           </select>
                           {validation.touched.warehouse &&
                           validation.errors.warehouse ? (

--- a/src/pages/Dashboards/Receipt/ReceiptReturn/ReceiptReturnCreate.tsx
+++ b/src/pages/Dashboards/Receipt/ReceiptReturn/ReceiptReturnCreate.tsx
@@ -401,9 +401,8 @@ const CreateReceiptReturn = (props: any) => {
                       value={validation.values.warehouse || ""}
                     >
                       <option value="">Chọn kho</option>
-                      <option value="Kho KS1">Kho KS1</option>
-                      <option value="Kho KS2">Kho KS2</option>
-                      <option value="Kho KH">Kho KH</option>
+                      <option value="KS">Kho KS</option>
+                      <option value="KH">Kho KH</option>
                     </select>
                     {validation.touched.warehouse &&
                     validation.errors.warehouse ? (

--- a/src/pages/Dashboards/Receipt/components/CreateProductModal.tsx
+++ b/src/pages/Dashboards/Receipt/components/CreateProductModal.tsx
@@ -493,9 +493,8 @@ const CreateProductModal: FC<props> = memo(
                               validation.values.warehouse || "Chọn"
                             }
                           >
-                            <option value="Kho KS1">Kho KS1</option>
-                            <option value="Kho KS2">Kho KS2</option>
-                            <option value="Kho KH">Kho KH</option>
+                            <option value="KS">Kho KS</option>
+                            <option value="KH">Kho KH</option>
                           </select>
                           {validation.touched.warehouse &&
                           validation.errors.warehouse ? (

--- a/src/pages/Dashboards/User/UserManagement.tsx
+++ b/src/pages/Dashboards/User/UserManagement.tsx
@@ -571,8 +571,7 @@ const UserManagement = () => {
                 value={validation.values.storeCode || ""}
               >
                 <option value="">Chọn chi nhánh</option>
-                <option value="KS1">KS1</option>
-                <option value="KS2">KS2</option>
+                <option value="KS">KS</option>
                 <option value="KH">KH</option>
               </select>
               {validation.touched.storeCode && validation.errors.storeCode ? (


### PR DESCRIPTION
Consolidates the warehouse and store code options across the application. The previous 'Kho KS1' and 'Kho KS2' options have been merged into a single 'KS' selection to simplify the user interface and standardize data.

- Updates warehouse selection in Product creation modal.
- Standardizes warehouse options in Receipt Check, Import, and Return forms.
- Unifies store code selection in User Management.