### PR TITLE
chore: set default status for receipt payment

### DIFF
--- a/src/pages/Dashboards/Receipt/ReceiptPayment/ReceiptPaymentCreate.tsx
+++ b/src/pages/Dashboards/Receipt/ReceiptPayment/ReceiptPaymentCreate.tsx
@@ -53,7 +53,7 @@ const ReceiptPaymentCreate: React.FC = () => {
     expenseType: ReceiptPaymentExpenseType.SUPPLIER_PAYMENT,
     amount: 0,
     paymentMethod: PaymentMethod.CASH,
-    status: ReceiptPaymentStatus.DRAFT,
+    status: ReceiptPaymentStatus.PAID,
     attachments: [],
   });
 


### PR DESCRIPTION
<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Changed the default status for receipt payment creation from ReceiptPaymentStatus.DRAFT to ReceiptPaymentStatus.PAID.</li>
<li>This modification affects the initial state object in the ReceiptPaymentCreate component.</li>
</ul></div>